### PR TITLE
Fix NullPointerException when no group_membership

### DIFF
--- a/src/main/java/com/exclamationlabs/connid/box/AbstractHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/AbstractHandler.java
@@ -12,6 +12,7 @@ import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueE
 import org.identityconnectors.framework.common.objects.Attribute;
 import org.identityconnectors.framework.common.objects.ConnectorObjectBuilder;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -87,7 +88,7 @@ public class AbstractHandler {
                 return (List<T>) attr.getValue();
             }
         }
-        return null;
+        return Collections.emptyList();
     }
 
     public static <T> void addAttr(ConnectorObjectBuilder builder, String attrName, T attrVal) {

--- a/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
@@ -394,7 +394,7 @@ public class UsersHandler extends AbstractHandler {
         info.getResource().updateInfo(info);
 
         List<String> attrGroups = getMultiAttr(attributes, ATTR_MEMBERSHIPS, String.class);
-        if(attrGroups != null){
+        if(!attrGroups.isEmpty()){
             attrGroups = new ArrayList<String>(attrGroups);
             Iterable<BoxGroupMembership.Info> memberships = user.getAllMemberships();
             for (BoxGroupMembership.Info membershipInfo : memberships){


### PR DESCRIPTION
Currently, `AbstractHandler#getMultiAttr` returns `null` when no group_membership. It causes `NullPointerException` as below when creating user without group_membership.

```
2019-10-10 09:47:15,578 [] [pool-3-thread-5] ERROR (com.evolveum.midpoint.web.component.progress.ProgressPanel): Error executing changes.
java.lang.NullPointerException: null
	at com.exclamationlabs.connid.box.UsersHandler.createUser(UsersHandler.java:311)
	at com.exclamationlabs.connid.box.BoxConnector.create(BoxConnector.java:130)
	at org.identityconnectors.framework.impl.api.local.operations.CreateImpl.create(CreateImpl.java:98)
```
