### PR TITLE
Support HTTP Proxy for the Box API Connection

### DIFF
--- a/src/main/java/com/exclamationlabs/connid/box/BoxConfiguration.java
+++ b/src/main/java/com/exclamationlabs/connid/box/BoxConfiguration.java
@@ -8,6 +8,7 @@
 package com.exclamationlabs.connid.box;
 
 import org.identityconnectors.common.StringUtil;
+import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.ConfigurationException;
 import org.identityconnectors.framework.spi.AbstractConfiguration;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
@@ -16,6 +17,10 @@ import org.identityconnectors.framework.spi.ConfigurationProperty;
 public class BoxConfiguration extends AbstractConfiguration {
 
     private String configFilePath;
+    private String httpProxyHost;
+    private int httpProxyPort;
+    private String httpProxyUser;
+    private GuardedString httpProxyPassword;
 
     @ConfigurationProperty(
             order = 1,
@@ -29,6 +34,62 @@ public class BoxConfiguration extends AbstractConfiguration {
 
     public void setConfigFilePath(String configFilePath) {
         this.configFilePath = configFilePath;
+    }
+
+    @ConfigurationProperty(
+            order = 2,
+            displayMessageKey = "HTTP Proxy Host",
+            helpMessageKey = "Hostname for the HTTP Proxy",
+            required = false,
+            confidential = false)
+    public String getHttpProxyHost() {
+        return httpProxyHost;
+    }
+
+    public void setHttpProxyHost(String httpProxyHost) {
+        this.httpProxyHost = httpProxyHost;
+    }
+
+    @ConfigurationProperty(
+            order = 3,
+            displayMessageKey = "HTTP Proxy Port",
+            helpMessageKey = "Port for the HTTP Proxy",
+            required = false,
+            confidential = false)
+    public int getHttpProxyPort() {
+        return httpProxyPort;
+    }
+
+    public void setHttpProxyPort(int httpProxyPort) {
+        this.httpProxyPort = httpProxyPort;
+    }
+
+    @ConfigurationProperty(
+            order = 4,
+            displayMessageKey = "HTTP Proxy User",
+            helpMessageKey = "Username for the HTTP Proxy Authentication",
+            required = false,
+            confidential = false)
+    public String getHttpProxyUser() {
+        return httpProxyUser;
+    }
+
+    public void setHttpProxyUser(String httpProxyUser) {
+        this.httpProxyUser = httpProxyUser;
+    }
+
+    @ConfigurationProperty(
+            order = 5,
+            displayMessageKey = "HTTP Proxy Password",
+            helpMessageKey = "Password for the HTTP Proxy Authentication",
+            required = false,
+            confidential = true)
+    public GuardedString getHttpProxyPassword() {
+        return httpProxyPassword;
+    }
+
+    public void setHttpProxyPassword(GuardedString httpProxyPassword) {
+        this.httpProxyPassword = httpProxyPassword;
     }
 
     @Override


### PR DESCRIPTION
We often deploy midPoint in the company network. In that case, we need to use HTTP Proxy for accessing Box API. So it's useful if this connector supports the proxy configuration.
