### PR TITLE
Fix create and update operations

### DIFF
--- a/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
@@ -280,7 +280,7 @@ public class UsersHandler extends AbstractHandler {
         //Administrative status
         if ((getAttr(attributes, OperationalAttributes.ENABLE_NAME, Boolean.class)) != null) {
             Boolean status = getAttr(attributes, OperationalAttributes.ENABLE_NAME, Boolean.class);
-            if (status != null) {
+            if (status) {
                 createUserParams.setStatus(BoxUser.Status.ACTIVE);
             } else {
                 createUserParams.setStatus(BoxUser.Status.INACTIVE);

--- a/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
@@ -328,6 +328,10 @@ public class UsersHandler extends AbstractHandler {
             throw new ConnectorIOException("Unable to confirm uid on box resource");
         }
 
+        String name = getStringAttr(attributes, "__NAME__");
+        if (name != null) {
+            info.setName(name);
+        }
         String attrAddress = getStringAttr(attributes, ATTR_ADDRESS);
         if (attrAddress != null) {
             info.setAddress(attrAddress);

--- a/src/test/java/com/exclamationlabs/connid/box/UsersHandlerTests.java
+++ b/src/test/java/com/exclamationlabs/connid/box/UsersHandlerTests.java
@@ -132,6 +132,26 @@ public class UsersHandlerTests {
     }
 
     @Test
+    public void updateName() {
+        BoxUser.Info userInfo = createTestUser();
+
+        Set<Attribute> attributes = new HashSet<>();
+        attributes.add(AttributeBuilder.build("__NAME__", "test_user_updated"));
+
+        UsersHandler usersHandler = new UsersHandler(boxAPIConnection);
+        usersHandler.updateUser(
+                new Uid(userInfo.getID()),
+                attributes
+        );
+
+        BoxUser.Info updatedUser = getTestUser();
+        assertNotNull(updatedUser);
+        assertEquals("test_user_updated", updatedUser.getName());
+
+        deleteTestUser();
+    }
+
+    @Test
     public void delete() {
         BoxUser.Info userInfo = createTestUser();
 


### PR DESCRIPTION
I found two bugs in create and update operations. This PR fixes these issues.

1. Can't set inactive status when creating a new user.
2. Can't update the user's name.
