### PR TITLE
Support changing email address

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.box</groupId>
             <artifactId>box-java-sdk</artifactId>
-            <version>2.8.2</version>
+            <version>2.44.0</version>
         </dependency>
         <!-- additional box sdk dependencies -->
         <dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.4.4</version>
+            <version>0.5.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -64,12 +64,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.52</version>
+            <version>1.60</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.52</version>
+            <version>1.60</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/com/exclamationlabs/connid/box/UsersHandlerTests.java
+++ b/src/test/java/com/exclamationlabs/connid/box/UsersHandlerTests.java
@@ -11,6 +11,7 @@ import com.box.sdk.*;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.common.objects.*;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.FileReader;
@@ -48,12 +49,16 @@ public class UsersHandlerTests {
     }
 
     private BoxUser.Info getTestUser() {
+        return getTestUser(testEmail);
+    }
+
+    private BoxUser.Info getTestUser(String email) {
         assertNotNull(boxAPIConnection);
 
         Iterable<BoxUser.Info> users = BoxUser.getAllEnterpriseUsers(boxAPIConnection);
 
         for (BoxUser.Info user : users) {
-            if (user.getLogin().equals(testEmail)) {
+            if (user.getLogin().equals(email)) {
                 return user;
             }
         }
@@ -73,12 +78,16 @@ public class UsersHandlerTests {
     }
 
     private void deleteTestUser() {
+        deleteTestUser(testEmail);
+    }
+
+    private void deleteTestUser(String email) {
         assertNotNull(boxAPIConnection);
 
         Iterable<BoxUser.Info> users = BoxUser.getAllEnterpriseUsers(boxAPIConnection);
 
         for (BoxUser.Info user : users) {
-            if (user.getLogin().equals(testEmail)) {
+            if (user.getLogin().equals(email)) {
                 user.getResource().delete(false, false);
             }
         }
@@ -149,6 +158,26 @@ public class UsersHandlerTests {
         assertEquals("test_user_updated", updatedUser.getName());
 
         deleteTestUser();
+    }
+
+    @Test
+    @Ignore("Test for updating email needs to be set up the target account with confirmed email in advance.")
+    public void updateEmail() {
+        String newEmail = "test-" + testEmail;
+
+        BoxUser.Info userInfo = getTestUser();
+
+        Set<Attribute> attributes = new HashSet<>();
+        attributes.add(AttributeBuilder.build("login", newEmail));
+
+        UsersHandler usersHandler = new UsersHandler(boxAPIConnection);
+        usersHandler.updateUser(
+                new Uid(userInfo.getID()),
+                attributes
+        );
+
+        BoxUser.Info updatedUser = getTestUser(newEmail);
+        assertNotNull(updatedUser);
     }
 
     @Test


### PR DESCRIPTION
I added a new feature that supports changing the user's email address (login field in the Box account).

To support it, we need to upgrade the Box Java SDK because the current version v.2.8.2 we use can't do the operation. For that operation, we need to use `is_confirmed` parameter for adding user's email alias which is introduced in v2.10.0:
https://github.com/box/box-java-sdk/pull/499
That's why I updated the dependencies in pom.xml.

Also, you may think updating email logic is a bit complicated. This is due to a limitation of the Box API. It doesn't support changing the email directly. It returns 400 error like `{"type":"error","status":400,"code":"bad_request","context_info":{"errors":[{"reason":"invalid_parameter","name":"new_primary_email","message":"Invalid value 'test-h2-wada@nri.co.jp'."}]},"help_url":"http:\/\/developers.box.com\/docs\/#errors","message":"Bad Request","request_id":"7nxpe8gbr9oftjue"}`.
We need to add an email alias first, then update the user with a new email, and finally, remove the old email.

Reference: https://community.box.com/t5/Platform-and-Development-Forum/How-to-change-user-s-primary-login-via-API/td-p/26483

