### PR TITLE
Fix executeQuery

### DIFF
--- a/src/main/java/com/exclamationlabs/connid/box/BoxConnector.java
+++ b/src/main/java/com/exclamationlabs/connid/box/BoxConnector.java
@@ -258,18 +258,12 @@ public class BoxConnector implements Connector,
 
 
         if (objectClass.is(ObjectClass.ACCOUNT_NAME)) {
-
             UsersHandler usersHandler = new UsersHandler(boxDeveloperEditionAPIConnection);
             usersHandler.query(query, handler, options);
 
-
         } else if (objectClass.is(ObjectClass.GROUP_NAME)) {
             GroupsHandler groupsHandler = new GroupsHandler(boxDeveloperEditionAPIConnection);
-            ArrayList<ConnectorObject> groups = groupsHandler.getAllGroups();
-
-            for (ConnectorObject groupConnectorObject : groups) {
-                handler.handle(groupConnectorObject);
-            }
+            groupsHandler.query(query, handler, options);
 
         } else {
             throw new UnsupportedOperationException("Unsupported object class " + objectClass);

--- a/src/main/java/com/exclamationlabs/connid/box/GroupsHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/GroupsHandler.java
@@ -179,14 +179,25 @@ public class GroupsHandler extends AbstractHandler {
         return new Uid(groupInfo.getID());
     }
 
-    public ArrayList<ConnectorObject> getAllGroups() {
-        ArrayList<ConnectorObject> connectorObjects = new ArrayList<>();
+    public void getAllGroups(ResultsHandler handler, OperationOptions ops) {
         Iterable<BoxGroup.Info> groups = BoxGroup.getAllGroups(boxDeveloperEditionAPIConnection);
         for (BoxGroup.Info groupInfo : groups) {
-            connectorObjects.add(groupToConnectorObject(groupInfo.getResource()));
+            handler.handle(groupToConnectorObject(groupInfo.getResource()));
         }
+    }
 
-        return connectorObjects;
+    public void query(String query, ResultsHandler handler, OperationOptions ops) {
+        LOGGER.info("GroupsHandler query VALUE: {0}", query);
+
+        if (query == null) {
+            getAllGroups(handler, ops);
+        } else {
+            BoxGroup group = new BoxGroup(boxDeveloperEditionAPIConnection, query);
+            ConnectorObject groupObject = groupToConnectorObject(group);
+            if(groupObject != null){
+                handler.handle(groupObject);
+            }
+        }
     }
 
     public Uid createGroup(Set<Attribute> attributes) {

--- a/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
@@ -181,28 +181,18 @@ public class UsersHandler extends AbstractHandler {
         return userSchemaInfo;
     }
 
-    public ArrayList<ConnectorObject> getAllUsers() {
-        ArrayList<ConnectorObject> connectorObjects = new ArrayList<>();
+    public void getAllUsers(ResultsHandler handler, OperationOptions ops) {
         Iterable<BoxUser.Info> users = BoxUser.getAllEnterpriseUsers(boxDeveloperEditionAPIConnection);
-
         for (BoxUser.Info user : users) {
-            connectorObjects.add(userToConnectorObject(user.getResource()));
+            handler.handle(userToConnectorObject(user.getResource()));
         }
-
-        return connectorObjects;
     }
 
     public void query(String query, ResultsHandler handler, OperationOptions ops) {
-
         LOGGER.info("UserHandler query VALUE: {0}", query);
 
         if (query == null) {
-
-            ArrayList<ConnectorObject> users = getAllUsers();
-
-            for (ConnectorObject userConnectorObject : users) {
-                handler.handle(userConnectorObject);
-            }
+            getAllUsers(handler, ops);
         } else {
             BoxUser user = new BoxUser(boxDeveloperEditionAPIConnection, query);
             ConnectorObject userObject = userToConnectorObject(user);
@@ -210,8 +200,6 @@ public class UsersHandler extends AbstractHandler {
                 handler.handle(userObject);
             }
         }
-
-
     }
 
     public Uid createUser(Set<Attribute> attributes) {


### PR DESCRIPTION
- Improve handling search results. Currently it creates object list temporarily which allocates memory.
- Support fetching a group object by id.