### PR TITLE
Add __ENABLE__ in user schema to detect activation/status capability

### DIFF
--- a/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/UsersHandler.java
@@ -176,6 +176,9 @@ public class UsersHandler extends AbstractHandler {
         attrMembership.setUpdateable(true);
         ocBuilder.addAttributeInfo(attrMembership.build());
 
+        // __ENABLE__
+        ocBuilder.addAttributeInfo(OperationalAttributeInfos.ENABLE);
+
         ObjectClassInfo userSchemaInfo = ocBuilder.build();
         LOGGER.info("The constructed User core schema: {0}", userSchemaInfo);
         return userSchemaInfo;


### PR DESCRIPTION
To generate the following native capability, I added `__ENABLE__` attribute info in user schema.

```
        <native>
            ...
            <cap:activation>
                <cap:status/>
            </cap:activation>
            ...
        </native>
```