### PR TITLE
Fix GroupsHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.exclamationlabs.connid.box</groupId>
     <artifactId>connector-box</artifactId>
-    <version>2.2</version>
+    <version>2.3</version>
     <name>ConnId Box Identity connector</name>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/exclamationlabs/connid/box/GroupsHandler.java
+++ b/src/main/java/com/exclamationlabs/connid/box/GroupsHandler.java
@@ -160,22 +160,27 @@ public class GroupsHandler extends AbstractHandler {
 
         // description
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_DESCRIPTION)
+                .setReturnedByDefault(STANDARD_ATTRS_SET.contains(ATTR_DESCRIPTION))
                 .build());
 
         // external_sync_identifier
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_EXTERNAL_SYNC_IDENTIFIER)
+                .setReturnedByDefault(STANDARD_ATTRS_SET.contains(ATTR_EXTERNAL_SYNC_IDENTIFIER))
                 .build());
 
         // invitability_level
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_INVITABILITY_LEVEL)
+                .setReturnedByDefault(STANDARD_ATTRS_SET.contains(ATTR_INVITABILITY_LEVEL))
                 .build());
 
         // member_viewability_level
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_MEMBER_VIEWABILITY_LEVEL)
+                .setReturnedByDefault(STANDARD_ATTRS_SET.contains(ATTR_MEMBER_VIEWABILITY_LEVEL))
                 .build());
 
         // provenance
         builder.addAttributeInfo(AttributeInfoBuilder.define(ATTR_PROVENANCE)
+                .setReturnedByDefault(STANDARD_ATTRS_SET.contains(ATTR_PROVENANCE))
                 .build());
 
         // Association
@@ -299,7 +304,7 @@ public class GroupsHandler extends AbstractHandler {
         BoxGroup.Info info = group.new Info();
 
         for (AttributeDelta delta : modifications) {
-            if (delta.getName().equals(ATTR_NAME)) {
+            if (delta.getName().equals(Name.NAME)) {
                 info.setName(getStringValue(delta));
 
             } else if (delta.getName().equals(ATTR_PROVENANCE)) {
@@ -320,7 +325,9 @@ public class GroupsHandler extends AbstractHandler {
         }
 
         try {
-            info.getResource().updateInfo(info);
+            if (info.getPendingChangesAsJsonObject() != null) {
+                info.getResource().updateInfo(info);
+            }
 
             // Box doesn't support to modify group's id
             return null;

--- a/src/test/java/com/exclamationlabs/connid/box/GroupUpdateTests.java
+++ b/src/test/java/com/exclamationlabs/connid/box/GroupUpdateTests.java
@@ -111,4 +111,30 @@ class GroupUpdateTests extends AbstractTests {
         assertNotNull(e);
         assertEquals(2, count.get());
     }
+
+    @Test
+    void renameGroup() {
+        // Given
+        String groupName = "Tech";
+
+        Set<AttributeDelta> modifications = new HashSet<>();
+        modifications.add(AttributeDeltaBuilder.build(Name.NAME, "Support"));
+
+        AtomicReference<BoxAPIRequest> request = new AtomicReference<>();
+        mockAPI.push(req -> {
+            request.set(req);
+
+            return ok("group-update.json");
+        });
+
+        // When
+        Set<AttributeDelta> sideEffects = connector.updateDelta(OBJECT_CLASS_GROUP,
+                new Uid("11446498", new Name(groupName)),
+                modifications, new OperationOptionsBuilder().build());
+
+        // Then
+        assertNotNull(request.get());
+        assertEquals("Support", getJsonAttr(request.get(), "name"));
+        assertNull(sideEffects);
+    }
 }


### PR DESCRIPTION
- Fixed issue where the name attribute could not be renamed
- Corrected the schema for several attributes, such as description, which are not fetched by default