### PR TITLE
Add maxRetryAttempts, connectionTimeout and readTimeout configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.box</groupId>
             <artifactId>box-java-sdk</artifactId>
-            <version>4.9.0</version>
+            <version>4.11.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.exclamationlabs.connid.box</groupId>
     <artifactId>connector-box</artifactId>
-    <version>2.3</version>
+    <version>2.4</version>
     <name>ConnId Box Identity connector</name>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/exclamationlabs/connid/box/BoxConfiguration.java
+++ b/src/main/java/com/exclamationlabs/connid/box/BoxConfiguration.java
@@ -26,6 +26,9 @@ public class BoxConfiguration extends AbstractConfiguration {
     private Boolean groupAdminDefaultPermissionCanEditAccounts;
     private Boolean groupAdminDefaultPermissionCanCInstantLogin;
     private Boolean groupAdminDefaultPermissionCanRunReports;
+    private int maxRetryAttempts = 5;
+    private int connectionTimeoutInMilliseconds = 10000;
+    private int readTimeoutInMilliseconds = 10000;
 
     @ConfigurationProperty(
             order = 1,
@@ -165,6 +168,48 @@ public class BoxConfiguration extends AbstractConfiguration {
 
     public void setGroupAdminDefaultPermissionCanRunReports(Boolean groupAdminDefaultPermissionCanRunReports) {
         this.groupAdminDefaultPermissionCanRunReports = groupAdminDefaultPermissionCanRunReports;
+    }
+
+    @ConfigurationProperty(
+            order = 11,
+            displayMessageKey = "Maximum retries",
+            helpMessageKey = "Configure how many times API will retry calls (Default: 5)",
+            required = false,
+            confidential = false)
+    public int getMaxRetryAttempts() {
+        return maxRetryAttempts;
+    }
+
+    public void setMaxRetryAttempts(int maxRetryAttempts) {
+        this.maxRetryAttempts = maxRetryAttempts;
+    }
+
+    @ConfigurationProperty(
+            order = 12,
+            displayMessageKey = "Connection Timeout (in milliseconds)",
+            helpMessageKey = "Set up how log (in milliseconds) API waits to establish connection (Default: 10000)",
+            required = false,
+            confidential = false)
+    public int getConnectionTimeoutInMilliseconds() {
+        return connectionTimeoutInMilliseconds;
+    }
+
+    public void setConnectionTimeoutInMilliseconds(int connectionTimeoutInMilliseconds) {
+        this.connectionTimeoutInMilliseconds = connectionTimeoutInMilliseconds;
+    }
+
+    @ConfigurationProperty(
+            order = 13,
+            displayMessageKey = "Read Timeout (in milliseconds)",
+            helpMessageKey = "Set up how log (in milliseconds) API waits to read data from connection (Default: 10000)",
+            required = false,
+            confidential = false)
+    public int getReadTimeoutInMilliseconds() {
+        return readTimeoutInMilliseconds;
+    }
+
+    public void setReadTimeoutInMilliseconds(int readTimeoutInMilliseconds) {
+        this.readTimeoutInMilliseconds = readTimeoutInMilliseconds;
     }
 
     @Override

--- a/src/main/java/com/exclamationlabs/connid/box/BoxConnector.java
+++ b/src/main/java/com/exclamationlabs/connid/box/BoxConnector.java
@@ -105,6 +105,10 @@ public class BoxConnector implements PoolableConnector,
             throw new ConnectorIOException("Failed to connect", e);
         }
 
+        boxDeveloperEditionAPIConnection.setMaxRetryAttempts(config.getMaxRetryAttempts());
+        boxDeveloperEditionAPIConnection.setConnectTimeout(config.getConnectionTimeoutInMilliseconds());
+        boxDeveloperEditionAPIConnection.setReadTimeout(config.getReadTimeoutInMilliseconds());
+
         boxDeveloperEditionAPIConnection.authenticate();
 
         this.boxAPI = boxDeveloperEditionAPIConnection;


### PR DESCRIPTION
I added three new configuration options.

- maxRetryAttempts
- connectionTimeout
- readTimeout

Additionally, the default timeout is set to 10 seconds. This is because the default timeout in the Box SDK is 0, meaning it will wait infinitely. In situations where the Box API does not respond correctly, this could cause midPoint thread to be blocked infinitely as the following thread stack, so the timeout is set to avoid this issue.

```
Thread state: WAITING
    at java.base@17.0.4.1/java.lang.Object.wait(Native Method)
    at java.base@17.0.4.1/java.lang.Object.wait(Object.java:338)
    at okhttp3.internal.http2.Http2Stream.waitForIo$okhttp(Http2Stream.kt:714)
    at okhttp3.internal.http2.Http2Stream.takeHeaders(Http2Stream.kt:140)
    at okhttp3.internal.http2.Http2ExchangeCodec.readResponseHeaders(Http2ExchangeCodec.kt:97)
    at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:110)
    at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:93)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
    at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
    at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
    at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
    at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
    at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
    at okhttp3.internal.connection.RealCall.execute(RealCall.kt:154)
    at com.box.sdk.BoxAPIConnection.executeOnClient(BoxAPIConnection.java:1258)
    at com.box.sdk.BoxAPIConnection.execute(BoxAPIConnection.java:1249)
    at com.box.sdk.BoxAPIRequest.trySend(BoxAPIRequest.java:616)
    at com.box.sdk.BoxAPIRequest.send(BoxAPIRequest.java:388)
    at com.box.sdk.BoxJSONRequest.send(BoxJSONRequest.java:106)
    at com.box.sdk.BoxJSONRequest.send(BoxJSONRequest.java:17)
    at com.box.sdk.BoxAPIRequest.send(BoxAPIRequest.java:355)
    at com.box.sdk.BoxJSONRequest.send(BoxJSONRequest.java:101)
    at com.box.sdk.BoxUser.getInfo(BoxUser.java:468)
    at com.exclamationlabs.connid.box.UsersHandler.getUser(UsersHandler.java:436)
    at com.exclamationlabs.connid.box.UsersHandler.query(UsersHandler.java:416)
    at com.exclamationlabs.connid.box.BoxConnector.executeQuery(BoxConnector.java:288)
    at com.exclamationlabs.connid.box.BoxConnector.executeQuery(BoxConnector.java:32)
    at org.identityconnectors.framework.impl.api.local.operations.SearchImpl.rawSearch(SearchImpl.java:197)
    at org.identityconnectors.framework.impl.api.local.operations.SearchImpl.search(SearchImpl.java:133)
```

 Also update to the latest Box SDK.